### PR TITLE
add sleep to prevent process loop from pinning cpu

### DIFF
--- a/profiler/manager.py
+++ b/profiler/manager.py
@@ -24,6 +24,7 @@ import signal
 import sys
 from datetime import datetime
 from multiprocessing import Queue
+from time import sleep
 
 # third party imports
 import scapy  # type: ignore
@@ -255,6 +256,7 @@ def start(args: argparse.Namespace):
 
     # keep main process alive until all subprocesses are finished or closed
     while processes:
+        sleep(0.1)
         for process in processes:
             if shutdown:
                 process.kill()


### PR DESCRIPTION
This PR closes #98 by adding a sleep function in the process watching loop, which appears to prevent pinning CPU at 100%.