### PR TITLE
add capability detection for VHT and HE Beamformee STS

### DIFF
--- a/CAPABILITY_LOGIC.md
+++ b/CAPABILITY_LOGIC.md
@@ -22,9 +22,11 @@ values to determine client capabilities.
         - MCS 0-9 if pairs are set to '11'
     - c. inspect octet 1 (one of the four vht capability octets)
         - if bit zero set to '1', client is SU Beam-formee capable
-    - d. inspect octet 2 (one of the four vht capability octets)
+    - d. inspect octect 1 (one of the four vht capability octets)
+        - add bit 5, 6, 7 to determine VHT Beamformee STS
+    - e. inspect octet 2 (one of the four vht capability octets)
         - if bit zero set to '1', client is MU Beam-formee capable     
-    - e. inspect octet 0 (one of the four vht capability octets)
+    - f. inspect octet 0 (one of the four vht capability octets)
         - if bit zero set to '1', client supports VHT 160 MHz 
 
 3. 802.11k: inspect tagged parameter 70 (RM Enabled Capabilities) - RM = radio management
@@ -91,6 +93,14 @@ values to determine client capabilities.
     - h. Buffer Status Report (BSR) support: B19 of HE PHY Capabilities
         - Y - supported
         - N - not supported 
+    - i. HE SU Beamformer: Bit 31 of HE PHY Capabilities
+        - 1 - supported
+        - 0 - not supported
+    - j. HE SU Beamformee: Bit 32 of HE PHY Capabilities
+        - 1 - supported
+        - 0 - not supported
+    - k. HE Beamformee STS: Bits 36-34 of HE PHY Capabilities
+        - Add Bits 36-34 to determine HE Beamformee STS
 
 10. 802.11ax spatial reuse: inspect spatial reuse tag number 39 (Spatial Reuse Parameter Set)
     - a. is Spatial Reuse Parameter Set tagged parameter present?

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 Unreleased (1.0.16)
 
 - Chipset lookup via heuristics
+- VHT Beamformee STS Capability
+- HE Beamformee STS Capability
 
 Release 1.0.15
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 wlanpi-profiler (1.0.16-dev.1) UNRELEASED; urgency=medium
 
   * Chipset lookup via heuristics
+  * VHT Beamformee STS Capability
+  * HE Beamformee STS Capability
 
  -- Josh Schmelzle <josh@joshschmelzle.com>  Sat, 22 Oct 2022 10:12:11 -0400
 

--- a/profiler/profiler.py
+++ b/profiler/profiler.py
@@ -602,6 +602,7 @@ class Profiler(object):
         dot11ac_mcs = Capability(db_key="dot11ac_mcs", db_value="")
         dot11ac_su_bf = Capability(db_key="dot11ac_su_bf", db_value=0)
         dot11ac_mu_bf = Capability(db_key="dot11ac_mu_bf", db_value=0)
+        dot11ac_bf_sts = Capability(db_key="dot11ac_bf_sts", db_value=0)
         dot11ac_160_mhz = Capability(db_key="dot11ac_160_mhz", db_value=0)
 
         if VHT_CAPABILITIES_IE_TAG in dot11_elt_dict.keys():
@@ -638,6 +639,7 @@ class Profiler(object):
             # check for SU & MU beam formee support
             mu_octet = dot11_elt_dict[VHT_CAPABILITIES_IE_TAG][2]
             su_octet = dot11_elt_dict[VHT_CAPABILITIES_IE_TAG][1]
+            bf_sts_octet = dot11_elt_dict[VHT_CAPABILITIES_IE_TAG][1]
             onesixty = dot11_elt_dict[VHT_CAPABILITIES_IE_TAG][0]
 
             # 160 MHz
@@ -664,6 +666,16 @@ class Profiler(object):
             else:
                 dot11ac.value += ", [ ] MU BF"
 
+            # BF STS
+            vht_bf_sts_binary_string = "{0}{1}{2}".format(
+                int(get_bit(bf_sts_octet, 5)),
+                int(get_bit(bf_sts_octet, 6)),
+                int(get_bit(bf_sts_octet, 7)),
+            )
+            vht_bf_sts_value = int(vht_bf_sts_binary_string, base=2)
+            dot11ac_bf_sts.db_value = vht_bf_sts_value
+            dot11ac.value += f", Beamformee STS={vht_bf_sts_value}"
+
         return [
             dot11ac,
             dot11ac_nss,
@@ -671,6 +683,7 @@ class Profiler(object):
             dot11ac_mcs,
             dot11ac_su_bf,
             dot11ac_mu_bf,
+            dot11ac_bf_sts,
         ]
 
     @staticmethod
@@ -902,6 +915,9 @@ class Profiler(object):
         dot11ax_he_su_beamformee = Capability(
             db_key="dot11ax_he_su_beamformee", db_value=0
         )
+        dot11ax_he_beamformee_sts = Capability(
+            db_key="dot11ax_he_beamformee_sts", db_value=0
+        )
         dot11ax_nss = Capability(db_key="dot11ax_nss", db_value=0)
         dot11ax_mcs = Capability(db_key="dot11ax_mcs", db_value="")
         dot11ax_twt = Capability(db_key="dot11ax_twt", db_value=0)
@@ -1019,6 +1035,18 @@ class Profiler(object):
                             dot11ax_he_su_beamformee.db_value = 0
                             dot11ax.value += ", [ ] SU Beamformee"
 
+                        # BF STS
+                        he_bf_sts_octet = element_data[11]
+
+                        he_bf_sts_binary_string = "{0}{1}{2}".format(
+                            int(get_bit(he_bf_sts_octet, 2)),
+                            int(get_bit(he_bf_sts_octet, 3)),
+                            int(get_bit(he_bf_sts_octet, 4)),
+                        )
+                        he_bf_sts_value = int(he_bf_sts_binary_string, base=2)
+                        dot11ax_he_beamformee_sts.db_value = he_bf_sts_value
+                        dot11ax.value += f", Beamformee STS={he_bf_sts_value}"
+
                         he_er_su_ppdu_octet = element_data[15]
                         he_er_su_ppdu_octet_binary_string = ""
                         for bit_position in range(8):
@@ -1091,6 +1119,7 @@ class Profiler(object):
             dot11ax_punctured_preamble,
             dot11ax_he_su_beamformer,
             dot11ax_he_su_beamformee,
+            dot11ax_he_beamformee_sts,
             dot11ax_he_er_su_ppdu,
             dot11ax_six_ghz,
             dot11ax_160_mhz,


### PR DESCRIPTION
Reference issue https://github.com/WLAN-Pi/wlanpi-profiler/issues/111.

This change adds detection for VHT Beamformee STS and HE Beamformee STS.

Text report example:
```ascii
---------------------------------------------
 - Client MAC: 1a:b2:70:4e:cf:16
 - OUI manufacturer lookup: Apple (Randomized MAC)
 - Chipset lookup: Broadcom
 - Frequency band: 5 GHz
 - Capture channel: 165
---------------------------------------------
802.11k                Supported             
802.11r                Supported             
802.11v                Supported             
802.11w                Supported             
802.11n                Supported (2ss)       
802.11ac               Supported (2ss), MCS 0-9, [ ] 160 MHz, [X] SU BF, [ ] MU BF, Beamformee STS=6
802.11ax               Supported (2ss), MCS 0-11, [ ] 160 MHz, [ ] TWT, [ ] Punctured Preamble, [ ] SU Beamformer, [X] SU Beamformee, Beamformee STS=7, [ ] HE ER SU PPDU, [ ] UORA, [X] BSR
Max Power              21 dBm                
Supported Channels     36-64, 100-144, 149-165**
Number of Channels     25   
```