### PR TITLE
Update INSTALLING_WITH_PIPX.md

### DIFF
--- a/INSTALLING_WITH_PIPX.md
+++ b/INSTALLING_WITH_PIPX.md
@@ -47,7 +47,7 @@ Note: it's important to use the `-p` argument to preserve the environment variab
 
 ```bash
 sudo su -p
-python3 -m pip install pipx
+python3 -m pip install -U pipx
 python3 -m pipx ensurepath
 exit
 ```


### PR DESCRIPTION
Should specify flag to upgrade pipx if already installed. 

Example:

```bash
root@wlanpi-neo2-tether:/home/wlanpi# python3 -m pip install pipx
Requirement already satisfied: pipx in /usr/local/lib/python3.7/dist-packages (0.15.4.0)
Requirement already satisfied: userpath in /usr/local/lib/python3.7/dist-packages (from pipx) (1.4.2)
Requirement already satisfied: argcomplete<2.0,>=1.9.4 in /usr/local/lib/python3.7/dist-packages (from pipx) (1.12.2)
Requirement already satisfied: distro; platform_system == "Linux" in /usr/local/lib/python3.7/dist-packages (from userpath->pipx) (1.5.0)
Requirement already satisfied: click in /usr/local/lib/python3.7/dist-packages (from userpath->pipx) (7.1.2)
Requirement already satisfied: importlib-metadata<4,>=0.23; python_version == "3.7" in /usr/local/lib/python3.7/dist-packages (from argcomplete<2.0,>=1.9.4->pipx) (3.4.0)
Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata<4,>=0.23; python_version == "3.7"->argcomplete<2.0,>=1.9.4->pipx) (3.4.0)
Requirement already satisfied: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.7/dist-packages (from importlib-metadata<4,>=0.23; python_version == "3.7"->argcomplete<2.0,>=1.9.4->pipx) (3.7.4.3)
root@wlanpi-neo2-tether:/home/wlanpi# python3 -m pip install -U pipx
Collecting pipx
  Downloading https://files.pythonhosted.org/packages/ee/a2/c219f3e5120c58bfd077340e32c5ac61545e0fb0020701e34a528035aa87/pipx-1.2.0-py3-none-any.whl (57kB)
    100% |████████████████████████████████| 61kB 974kB/s 
Requirement already satisfied, skipping upgrade: importlib-metadata>=3.3.0; python_version < "3.8" in /usr/local/lib/python3.7/dist-packages (from pipx) (3.4.0)
Requirement already satisfied, skipping upgrade: argcomplete>=1.9.4 in /usr/local/lib/python3.7/dist-packages (from pipx) (1.12.2)
Collecting userpath>=1.6.0 (from pipx)
  Downloading https://files.pythonhosted.org/packages/45/72/e8cf3e440a4719253cf114c091ae84e7a07394dbb44983f3a561f40f80b6/userpath-1.8.0-py3-none-any.whl
Collecting packaging>=20.0 (from pipx)
  Cache entry deserialization failed, entry ignored
  Downloading https://files.pythonhosted.org/packages/ab/c3/57f0601a2d4fe15de7a553c00adbc901425661bf048f2a22dfc500caf121/packaging-23.1-py3-none-any.whl (48kB)
    100% |████████████████████████████████| 51kB 1.4MB/s 
Requirement already satisfied, skipping upgrade: typing-extensions>=3.6.4; python_version < "3.8" in /usr/local/lib/python3.7/dist-packages (from importlib-metadata>=3.3.0; python_version < "3.8"->pipx) (3.7.4.3)
Requirement already satisfied, skipping upgrade: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata>=3.3.0; python_version < "3.8"->pipx) (3.4.0)
Requirement already satisfied, skipping upgrade: click in /usr/local/lib/python3.7/dist-packages (from userpath>=1.6.0->pipx) (7.1.2)
Installing collected packages: userpath, packaging, pipx
  Found existing installation: userpath 1.4.2
    Uninstalling userpath-1.4.2:
      Successfully uninstalled userpath-1.4.2
  Found existing installation: pipx 0.15.4.0
    Uninstalling pipx-0.15.4.0:
      Successfully uninstalled pipx-0.15.4.0
Successfully installed packaging-23.1 pipx-1.2.0 userpath-1.8.0
```