### PR TITLE
Bookworm uses py3.11, don't test py3.12 for now

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.11"]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
See title.