### PR TITLE
Attempt to fix pkg deploy CI with reusable workflow

### DIFF
--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -18,14 +18,13 @@ jobs:
     uses: WLAN-Pi/gh-workflows/.github/workflows/get-formatted-version-string.yml@main
   sbuild_deploy:
     name: sbuild deploy pkg
-    environment: PACKAGECLOUD
-    secrets: inherit
     needs: 
       - format
     uses: WLAN-Pi/gh-workflows/.github/workflows/sbuild-deploy-pkg.yml@main
     with:
       pkg: wlanpi-profiler
       version: ${{ needs.format.outputs.version }} 
+    secrets: inherit
   slack-workflow-status:
     if: ${{ always() && (! github.event.pull_request.head.repo.fork) }}
     name: Post workflow status to Slack

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wlanpi-profiler (1.0.18-2) unstable; urgency=medium
+wlanpi-profiler (1.0.18-1) unstable; urgency=medium
 
   * Fix crash when an (re)association request is seen without an SSID element
 


### PR DESCRIPTION
https://github.com/WLAN-Pi/wlanpi-profiler/actions/runs/11173717285

```
[Invalid workflow file: .github/workflows/deploy-to-packagecloud.yml#L22](https://github.com/WLAN-Pi/wlanpi-profiler/actions/runs/11173717285/workflow)
The workflow is not valid. .github/workflows/deploy-to-packagecloud.yml (Line: 22, Col: 5): Unexpected value 'secrets' .github/workflows/deploy-to-packagecloud.yml (Line: 25, Col: 5): Unexpected value 'uses'
```