### PR TITLE
fix workflow needs on slack status

### DIFF
--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ always() && (! github.event.pull_request.head.repo.fork) }}
     name: Post workflow status to Slack
     needs:
-      - sbuild
+      - sbuild_deploy
     runs-on: "${{ vars.RUNS_ON || 'ubuntu-22.04' }}"
     steps:
       - name: Slack Workflow Notification

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wlanpi-profiler (1.0.18-1) unstable; urgency=medium
+wlanpi-profiler (1.0.18-2) unstable; urgency=medium
 
   * Fix crash when an (re)association request is seen without an SSID element
 


### PR DESCRIPTION
```
[Invalid workflow file: .github/workflows/deploy-to-packagecloud.yml#L32](https://github.com/WLAN-Pi/wlanpi-profiler/actions/runs/11173808315/workflow)
The workflow is not valid. .github/workflows/deploy-to-packagecloud.yml (Line: 32, Col: 9): Job 'slack-workflow-status' depends on unknown job 'sbuild'.
```

https://github.com/WLAN-Pi/wlanpi-profiler/actions/runs/11173808315