### PR TITLE
Add template chooser

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: WLAN Pi Feedback
+    url: https://github.com/WLAN-Pi/feedback/discussions
+    about: Please ask and answer questions here. Don't open issues for usage questions.


### PR DESCRIPTION
This PR attempts to enable the templates that were added in #213 based on https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser. 