### PR TITLE
Fix form schema typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ body:
     attributes:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      values: |
+      value: |
         * Run `$ sudo profiler --debug`, reproduce the issue, and paste in the full output.
         * Run `$ sudo profiler --list_interfaces`, and paste in the full output.
       render: shell


### PR DESCRIPTION
## Description

Fixed typo in syntax for attributes of a textarea in GitHub's form schema. 