### PR TITLE
Fix hostapd crash from No IR/DFS flags by adding channel checks after LAR scan

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">52%</text>
-        <text x="80" y="14">52%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">51%</text>
+        <text x="80" y="14">51%</text>
     </g>
 </svg>

--- a/profiler/interface.py
+++ b/profiler/interface.py
@@ -696,9 +696,7 @@ class Interface:
                         f"Available in {band_name} band: {', '.join(map(str, sample))}"
                     )
                     if flag:
-                        error_lines.append(
-                            f"Try with --channel {sample[0]} {flag}"
-                        )
+                        error_lines.append(f"Try with --channel {sample[0]} {flag}")
                     else:
                         error_lines.append(f"Try with --channel {sample[0]}")
                     error_lines.append("")


### PR DESCRIPTION
## Summary

Adds channel checks after LAR scan and fix hostapd crashing due to No IR/DFS flags after LAR scan

- Add method that runs after both interface staging and LAR scan to verify the selected channel is usable for AP operation.
- Detect and report "Disabled", "No IR", and "Radar Detection"
- Display human-readable band names (2.4 GHz, 5 GHz, 6 GHz)
- Exit with a more helpful error message and include alternative channel suggestions
- Clean up debug output from error messages

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

<!-- What problem does this solve? What was changed? -->

Improves channel restriction detection

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [X] I used AI/LLM assistance
- If yes: Tool(s) used: Claude Opus 4.6 and Kimi K2.5

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [ ] This PR fixes/closes issue #_ (or relates to issue #_)

## Breaking changes

<!-- Only fill out if you checked "Breaking change" above -->

- **What breaks:** 
- **Migration needed:** 
