### PR TITLE
Fix pip upgrade option typo in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,7 +14,7 @@ source venv/bin/activate
 3. Update and install tools 
 
 ```bash
-pip install -u pip pip-tools setuptools wheel
+pip install -U pip pip-tools setuptools wheel
 ```
 
 4. Install depends


### PR DESCRIPTION
This PR fixes a typo in DEVELOPMENT.md where the pip upgrade option was written as lowercase -u instead of uppercase -U. Closes #249.